### PR TITLE
Fix path compatibility of .fbx textures

### DIFF
--- a/Source/Utils.cpp
+++ b/Source/Utils.cpp
@@ -944,6 +944,15 @@ bool utils::LoadScene(const std::string& path, Scene& scene, bool simpleOIT, con
 
             if (assimpMaterial->GetTexture(type, 0, &str) == AI_SUCCESS)
             {
+#if !(_WIN32)
+                // In order to import .fbx textures on Linux
+                for (char* it = str.data; it != str.data + str.length; ++it)
+                {
+                    if (*it == '\\')
+                        *it = '/';
+                }
+#endif
+                
                 std::string texPath = baseDir + str.data;
                 const uint64_t hash = ComputeHash(texPath.c_str(), (uint32_t)texPath.length());
 


### PR DESCRIPTION
Studying NRD sample on Linux (Ubuntu 20.04).
.fbx textures won't load due to WIN32-Linux path incompatibility.
Maybe there is a better fix but for now this is a fix that works for me.
Please if you pull this request also update samples submodules in order to get this fix.

Thank you in advance