### PR TITLE
Updated hashbang and permissions for shell scripts

### DIFF
--- a/1-Deploy.sh
+++ b/1-Deploy.sh
@@ -1,11 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
 git submodule update --init --recursive
-
-chmod +x "External/NRI/External/Packman/packman.sh"
-chmod +x "2-Build.sh"
-chmod +x "3-Prepare NRI SDK.sh"
-chmod +x "4-Clean.sh"
 
 mkdir -p "_Build"
 

--- a/2-Build.sh
+++ b/2-Build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 mkdir -p "_Build"
 

--- a/4-Clean.sh
+++ b/4-Clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 rm -rf "build"
 

--- a/Include/NRIFramework.h
+++ b/Include/NRIFramework.h
@@ -10,7 +10,7 @@
 // 3rd party
 #define GLFW_INCLUDE_NONE
 #include "Glfw/include/GLFW/glfw3.h"
-#include "ImGui/imgui.h"
+#include "Imgui/imgui.h"
 
 // Dependencies
 #include "MathLib/MathLib.h"


### PR DESCRIPTION
Git is tracking file permissions, so using `chmod +x` in shell scripts is redundant. To make a shell script executable, it's enough to execute `chmod +x` and commit the file. On Windows, it's possible to use the next command:
```
git update-index --chmod=+x <path_to_shell>
```

The source command is not compatible with sh specification, thus hash-bang points to bash. All scripts touched for consistency.

Also, was fixed an imgui include path.
Paths in Unix and Unit-like systems are case-sensitive, so the `imgui.h` was not observable