### PR TITLE
Small fixes for Linux build

### DIFF
--- a/Include/NRIFramework.h
+++ b/Include/NRIFramework.h
@@ -14,7 +14,7 @@
 // 3rd party
 #define GLFW_INCLUDE_NONE
 #include "Glfw/include/GLFW/glfw3.h"
-#include "ImGui/imgui.h"
+#include "Imgui/imgui.h"
 
 // NRI: core & common extensions
 #include "NRI.h"

--- a/Source/DebugAllocator.cpp
+++ b/Source/DebugAllocator.cpp
@@ -2,6 +2,8 @@
 #    include <windows.h>
 #endif
 
+#include <atomic>
+
 #include "NRIFramework.h"
 
 struct DebugAllocator {

--- a/Source/Utils.cpp
+++ b/Source/Utils.cpp
@@ -650,7 +650,7 @@ static const cgltf_image* ParseDdsImage(const cgltf_texture* texture, const cglt
 }
 
 void DecomposeAffine(const float4x4& transform, float3& translation, float4& rotation, float3& scale) {
-    translation = transform.col3.xyz;
+    translation = (float3) transform.col3;
 
     float3 col0 = transform.col0;
     float3 col1 = transform.col1;


### PR DESCRIPTION
Adds an `#include <atomic>` to `DebugAllocator.cpp` and changes the `imgui` include, which, apparently, was done proper as a part of #4 in commit 91fc5b2 but regressed in commit 9c7432f. 

It is a draft PR for now until #6 is resolved.