### PR TITLE
Fix Linux gcc14 build

### DIFF
--- a/Source/SampleBase.cpp
+++ b/Source/SampleBase.cpp
@@ -1,7 +1,10 @@
 // © 2021 NVIDIA Corporation
 
 #include "NRIFramework.h"
+
+#if defined _WIN32
 #include "NRIAgilitySDK.h"
+#endif
 
 #if defined _WIN32
 #    define GLFW_EXPOSE_NATIVE_WIN32

--- a/Source/Utils.cpp
+++ b/Source/Utils.cpp
@@ -650,11 +650,11 @@ static const cgltf_image* ParseDdsImage(const cgltf_texture* texture, const cglt
 }
 
 void DecomposeAffine(const float4x4& transform, float3& translation, float4& rotation, float3& scale) {
-    translation = (float3) transform.col3.xyz;
+    translation = (float3)((float4)transform.col3).xyz;
 
-    float3 col0 = transform.col0.xyz;
-    float3 col1 = transform.col1.xyz;
-    float3 col2 = transform.col2.xyz;
+    float3 col0 = (float3)((float4)transform.col0).xyz;
+    float3 col1 = (float3)((float4)transform.col1).xyz;
+    float3 col2 = (float3)((float4)transform.col2).xyz;
 
     scale.x = length(col0);
     scale.y = length(col1);


### PR DESCRIPTION
Two fixes:

1. `#include "NRIAgilitySDK.h"` - for some reason in Linux build
2. in gcc14.2.1 - (float3) transform.col3.xyz does not work when `(float3)((float4)transform.col3).xyz` fix it
![1](https://github.com/user-attachments/assets/7a36911d-1895-4473-bdc9-7fa1b8883df6)
