### PR TITLE
Linux workaround

### DIFF
--- a/Source/SampleBase.cpp
+++ b/Source/SampleBase.cpp
@@ -411,6 +411,7 @@ bool SampleBase::InitImgui(nri::Device& device) {
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;
     io.IniFilename = nullptr;
 
+#ifdef WIN32
     m_MouseCursors[ImGuiMouseCursor_Arrow] = glfwCreateStandardCursor(GLFW_ARROW_CURSOR);
     m_MouseCursors[ImGuiMouseCursor_TextInput] = glfwCreateStandardCursor(GLFW_IBEAM_CURSOR);
     m_MouseCursors[ImGuiMouseCursor_ResizeAll] = glfwCreateStandardCursor(GLFW_RESIZE_ALL_CURSOR);
@@ -419,6 +420,7 @@ bool SampleBase::InitImgui(nri::Device& device) {
     m_MouseCursors[ImGuiMouseCursor_ResizeNESW] = glfwCreateStandardCursor(GLFW_RESIZE_NESW_CURSOR);
     m_MouseCursors[ImGuiMouseCursor_ResizeNWSE] = glfwCreateStandardCursor(GLFW_RESIZE_NWSE_CURSOR);
     m_MouseCursors[ImGuiMouseCursor_Hand] = glfwCreateStandardCursor(GLFW_HAND_CURSOR);
+#endif
 
     // Font
     ImFontConfig fontConfig = {};


### PR DESCRIPTION
On X11, GLFW would report:
"X11: Standard cursor shape unavailable"
leading to program termination.
It works without the calls to glfwCreateStandardCursor().