### PR TITLE
Update SampleBase.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # VS Code
 .vscode/
 
+# CLion
+.idea
+
 # ninja
 .ninja_deps
 .ninja_log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ string(REGEX MATCH "NRI_FRAMEWORK_VERSION_MINOR ([0-9]*)" _ ${ver_h})
 set(VERSION_MINOR ${CMAKE_MATCH_1})
 
 message("NRI framework v${VERSION_MAJOR}.${VERSION_MINOR}")
-project(NRIFramework LANGUAGES C CXX)
+project(NRIFramework LANGUAGES C CXX OBJC)
 
 # Globals?
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ string(REGEX MATCH "NRI_FRAMEWORK_VERSION_MINOR ([0-9]*)" _ ${ver_h})
 set(VERSION_MINOR ${CMAKE_MATCH_1})
 
 message("NRI framework v${VERSION_MAJOR}.${VERSION_MINOR}")
-project(NRIFramework LANGUAGES C CXX OBJC)
+project(NRIFramework LANGUAGES C CXX)
+
+if (APPLE)
+    enable_language(OBJC)
+endif ()
 
 # Globals?
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/Source/SampleBase.cpp
+++ b/Source/SampleBase.cpp
@@ -541,8 +541,23 @@ bool SampleBase::Create(int32_t argc, char** argv, const char* windowTitle) {
     glfwWindowHint(GLFW_DECORATED, decorated ? 1 : 0);
     glfwWindowHint(GLFW_RESIZABLE, 0);
 
+    nri::GraphicsAPI graphicsAPI = nri::GraphicsAPI::VK;  // Default fallback
+    std::string apiName = "VULKAN";  // Default name
+
+    std::string selectedApi = cmdLine.get<std::string>("api");
+    if (selectedApi == "D3D11") {
+        graphicsAPI = nri::GraphicsAPI::D3D11;
+        apiName = "D3D11";
+    } else if (selectedApi == "D3D12") {
+        graphicsAPI = nri::GraphicsAPI::D3D12;
+        apiName = "D3D12";
+    } else if (selectedApi == "VULKAN") {
+        graphicsAPI = nri::GraphicsAPI::VK;
+        apiName = "VULKAN";
+    }
+
     char windowName[256];
-    snprintf(windowName, sizeof(windowName), "%s [%s]", windowTitle, cmdLine.get<std::string>("api").c_str());
+    snprintf(windowName, sizeof(windowName), "%s [%s]", windowTitle, apiName.c_str());
 
     m_Window = glfwCreateWindow(m_WindowResolution.x, m_WindowResolution.y, windowName, NULL, NULL);
     if (!m_Window) {
@@ -570,12 +585,6 @@ bool SampleBase::Create(int32_t argc, char** argv, const char* windowTitle) {
 
     // Main initialization
     printf("Loading...\n");
-
-    nri::GraphicsAPI graphicsAPI = nri::GraphicsAPI::VK;
-    if (cmdLine.get<std::string>("api") == "D3D11")
-        graphicsAPI = nri::GraphicsAPI::D3D11;
-    else if (cmdLine.get<std::string>("api") == "D3D12")
-        graphicsAPI = nri::GraphicsAPI::D3D12;
 
     bool result = Initialize(graphicsAPI);
 

--- a/Source/SampleBase.cpp
+++ b/Source/SampleBase.cpp
@@ -541,23 +541,18 @@ bool SampleBase::Create(int32_t argc, char** argv, const char* windowTitle) {
     glfwWindowHint(GLFW_DECORATED, decorated ? 1 : 0);
     glfwWindowHint(GLFW_RESIZABLE, 0);
 
-    nri::GraphicsAPI graphicsAPI = nri::GraphicsAPI::VK;  // Default fallback
-    std::string apiName = "VULKAN";  // Default name
-
+    nri::GraphicsAPI graphicsAPI = nri::GraphicsAPI::VK;  // Default
     std::string selectedApi = cmdLine.get<std::string>("api");
     if (selectedApi == "D3D11") {
         graphicsAPI = nri::GraphicsAPI::D3D11;
-        apiName = "D3D11";
     } else if (selectedApi == "D3D12") {
         graphicsAPI = nri::GraphicsAPI::D3D12;
-        apiName = "D3D12";
     } else if (selectedApi == "VULKAN") {
         graphicsAPI = nri::GraphicsAPI::VK;
-        apiName = "VULKAN";
     }
 
     char windowName[256];
-    snprintf(windowName, sizeof(windowName), "%s [%s]", windowTitle, apiName.c_str());
+    snprintf(windowName, sizeof(windowName), "%s [%s]", windowTitle, nri::nriGetGraphicsAPIString(graphicsAPI));
 
     m_Window = glfwCreateWindow(m_WindowResolution.x, m_WindowResolution.y, windowName, NULL, NULL);
     if (!m_Window) {


### PR DESCRIPTION
Since window name is get before actually selecting the API we display the wrong window name, also we can't set VULKAN from commandline even though help shows we should be able to: `graphics API: D3D11, D3D12 or VULKAN (string [=D3D12])`. This fixes the problem determining API before window creation.